### PR TITLE
fix: remove non-existent alpha branch from semantic-release config

### DIFF
--- a/.releaserc.json
+++ b/.releaserc.json
@@ -3,10 +3,6 @@
     {
       "name": "main",
       "prerelease": "beta"
-    },
-    {
-      "name": "alpha",
-      "prerelease": true
     }
   ],
   "plugins": [


### PR DESCRIPTION
semantic-release was failing with ERELEASEBRANCHES error because

alpha branch doesn't exist on remote. Remove alpha branch

configuration to fix the release process.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated release branch configuration to remove the "alpha" branch; only the "main" branch is now used for prerelease versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->