### PR TITLE
fix: increase commitlint line length limits from 100 to 200 characters

### DIFF
--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -20,6 +20,7 @@ export default {
     ],
     'subject-case': [2, 'never', ['upper-case', 'pascal-case']],
     'subject-max-length': [2, 'always', 100],
-    'body-max-line-length': [2, 'always', 100],
+    'body-max-line-length': [2, 'always', 200],
+    'footer-max-line-length': [2, 'always', 200],
   },
 };


### PR DESCRIPTION
GitHub squash commits often create longer lines that exceed the 100 character limit, causing CI failures. Increase both body-max-line-length and footer-max-line-length to 200 characters for better compatibility with GitHub's squash merge behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Increased the maximum allowed line length for commit message bodies and footers to 200 characters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->