### PR TITLE
feat: add GPG signing support to semantic-release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,6 +27,14 @@ jobs:
         with:
           fetch-depth: 0
           
+      - name: Import GPG key
+        uses: crazy-max/ghaction-import-gpg@v6
+        with:
+          gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
+          passphrase: ${{ secrets.GPG_PASSPHRASE }}
+          git_user_signingkey: true
+          git_commit_gpgsign: true
+          
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -21,7 +21,8 @@
       "@semantic-release/git",
       {
         "assets": ["package.json", "CHANGELOG.md"],
-        "message": "chore(release): ${nextRelease.version} [skip ci]"
+        "message": "chore(release): ${nextRelease.version} [skip ci]",
+        "signCommits": true
       }
     ]
   ]


### PR DESCRIPTION
- Configure semantic-release to sign commits with signCommits: true
- Add GPG key import step to release workflow using crazy-max/ghaction-import-gpg@v6
- Enable git commit signing in CI environment