### PR TITLE
fix: update git user configuration in release workflow for GPG signing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,8 +36,8 @@ jobs:
           git_commit_gpgsign: true
           git_tag_gpgsign: true
           git_config_global: true
-          git_user_name: ${{ secrets.GIT_USER_NAME }}
-          git_user_email: ${{ secrets.GIT_USER_EMAIL }}
+          git_committer_name: ${{ secrets.GIT_USER_NAME }}
+          git_committer_email: ${{ secrets.GIT_USER_EMAIL }}
 
       - name: Setup Node.js
         uses: actions/setup-node@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,8 +36,8 @@ jobs:
           git_commit_gpgsign: true
           git_tag_gpgsign: true
           git_config_global: true
-          git_committer_name: ${{ secrets.GIT_USER_NAME }}
-          git_committer_email: ${{ secrets.GIT_USER_EMAIL }}
+          git_committer_name: ${{ secrets.GIT_COMMITTER_NAME }}
+          git_committer_email: ${{ secrets.GIT_COMMITTER_EMAIL }}
 
       - name: Setup Node.js
         uses: actions/setup-node@v4


### PR DESCRIPTION
- Changed git_user_name and git_user_email to git_committer_name and git_committer_email for improved clarity and consistency in the release process.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the release workflow configuration to use new committer identity parameters for GPG signing. No changes to application features or user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->