### PR TITLE
chore: update Git user configuration to use vars in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -72,10 +72,10 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
           # Ensure semantic-release uses the same identity as the GPG key
-          GIT_AUTHOR_NAME: ${{ env.GIT_COMMITTER_NAME }}
-          GIT_AUTHOR_EMAIL: ${{ env.GIT_COMMITTER_EMAIL }}
-          GIT_COMMITTER_NAME: ${{ env.GIT_COMMITTER_NAME }}
-          GIT_COMMITTER_EMAIL: ${{ env.GIT_COMMITTER_EMAIL }}
+          GIT_AUTHOR_NAME: ${{ vars.GIT_COMMITTER_NAME }}
+          GIT_AUTHOR_EMAIL: ${{ vars.GIT_COMMITTER_EMAIL }}
+          GIT_COMMITTER_NAME: ${{ vars.GIT_COMMITTER_NAME }}
+          GIT_COMMITTER_EMAIL: ${{ vars.GIT_COMMITTER_EMAIL }}
           GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
           GPG_PRIVATE_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
         run: npx semantic-release


### PR DESCRIPTION
- Transitioned from using env to vars for Git committer name and email in the release workflow, improving consistency and clarity in the configuration.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the configuration of the release workflow to use repository or organization-level variables for Git author and committer identity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->