### PR TITLE
chore: enhance release workflow with CodeQL checks

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,6 +26,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Import GPG key
         uses: crazy-max/ghaction-import-gpg@01dd5d3ca463c7f10f7f4f7b4f177225ac661ee4 # v6.1.0
@@ -67,9 +68,26 @@ jobs:
       - name: Run build
         run: npm run build
 
+      - name: Wait for CodeQL workflow to complete
+        uses: lewagon/wait-on-check-action@v1.3.4
+        with:
+          ref: ${{ github.sha }}
+          check-name: 'Analyze (actions)'
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          wait-interval: 30
+
+      - name: Wait for CodeQL workflow to complete (JS/TS)
+        uses: lewagon/wait-on-check-action@v1.3.4
+        with:
+          ref: ${{ github.sha }}
+          check-name: 'Analyze (javascript-typescript)'
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          wait-interval: 30
+
       - name: Release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.GH_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
           # Ensure semantic-release uses the same identity as the GPG key
           GIT_AUTHOR_NAME: ${{ vars.GIT_COMMITTER_NAME }}


### PR DESCRIPTION
- Added steps to wait for CodeQL workflow completion for both general analysis and JavaScript/TypeScript, ensuring code quality checks are completed before release.
- Set persist-credentials to false in the checkout step for improved security.
